### PR TITLE
Add Taggable support to all specs & builders

### DIFF
--- a/src/main/java/io/outfoxx/typescriptpoet/ClassSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/ClassSpec.kt
@@ -23,7 +23,7 @@ import io.outfoxx.typescriptpoet.CodeBlock.Companion.joinToCode
 class ClassSpec
 private constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
 
   val name = builder.name
   val javaDoc = builder.javaDoc.build()
@@ -202,7 +202,7 @@ private constructor(
 
   class Builder(
      internal val name: String
-  ) {
+  ) : Taggable.Builder<Builder>() {
 
     internal val javaDoc = CodeBlock.builder()
     internal val decorators = mutableListOf<DecoratorSpec>()

--- a/src/main/java/io/outfoxx/typescriptpoet/DecoratorSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/DecoratorSpec.kt
@@ -21,7 +21,7 @@ package io.outfoxx.typescriptpoet
 class DecoratorSpec
 internal constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val parameters = builder.parameters
   val factory = builder.factory
@@ -71,7 +71,7 @@ internal constructor(
   class Builder
   internal constructor(
      val name: SymbolSpec
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val parameters = mutableListOf<Pair<String?, CodeBlock>>()
     internal var factory: Boolean? = null
 

--- a/src/main/java/io/outfoxx/typescriptpoet/EnumSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/EnumSpec.kt
@@ -21,7 +21,7 @@ package io.outfoxx.typescriptpoet
 class EnumSpec
 private constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val javaDoc = builder.javaDoc.build()
   val modifiers = builder.modifiers.toImmutableSet()
@@ -69,7 +69,7 @@ private constructor(
   internal constructor(
      val name: String,
      val constants: MutableMap<String, CodeBlock?> = mutableMapOf()
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val javaDoc = CodeBlock.builder()
     internal val modifiers = mutableListOf<Modifier>()
 

--- a/src/main/java/io/outfoxx/typescriptpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/FileSpec.kt
@@ -37,7 +37,7 @@ import java.nio.file.Paths
 class FileSpec
 private constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
   val path = builder.path
   val comment = builder.comment.build()
   val members = builder.members.toList()
@@ -218,7 +218,7 @@ private constructor(
 
   class Builder internal constructor(
      internal val path: Path
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val comment = CodeBlock.builder()
     internal var indent = "  "
     internal val members = mutableListOf<Any>()

--- a/src/main/java/io/outfoxx/typescriptpoet/FunctionSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/FunctionSpec.kt
@@ -21,7 +21,7 @@ package io.outfoxx.typescriptpoet
 class FunctionSpec
 private constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val javaDoc = builder.javaDoc.build()
   val decorators = builder.decorators.toImmutableList()
@@ -138,7 +138,9 @@ private constructor(
     return builder
   }
 
-  class Builder internal constructor(internal val name: String) {
+  class Builder internal constructor(
+    internal val name: String
+  ) : Taggable.Builder<Builder>() {
     internal val javaDoc = CodeBlock.builder()
     internal val decorators = mutableListOf<DecoratorSpec>()
     internal val modifiers = mutableSetOf<Modifier>()

--- a/src/main/java/io/outfoxx/typescriptpoet/InterfaceSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/InterfaceSpec.kt
@@ -23,7 +23,7 @@ import io.outfoxx.typescriptpoet.CodeBlock.Companion.joinToCode
 class InterfaceSpec
 private constructor(
    builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
 
   val name = builder.name
   val javaDoc = builder.javaDoc.build()
@@ -103,8 +103,8 @@ private constructor(
   }
 
   class Builder(
-     internal val name: String
-  ) {
+    internal val name: String
+  ) : Taggable.Builder<Builder>() {
 
     internal val javaDoc = CodeBlock.builder()
     internal val modifiers = mutableListOf<Modifier>()

--- a/src/main/java/io/outfoxx/typescriptpoet/ModuleSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/ModuleSpec.kt
@@ -21,7 +21,7 @@ package io.outfoxx.typescriptpoet
 class ModuleSpec
 private constructor(
   builder: Builder
-) {
+) : Taggable(builder.tags.toImmutableMap()) {
 
   enum class Type(val keyword: String) {
     MODULE("module"),
@@ -96,7 +96,7 @@ private constructor(
   internal constructor(
     internal val name: String,
     internal val type: Type = Type.NAMESPACE
-  ) {
+  ) : Taggable.Builder<Builder>() {
 
     internal val javaDoc = CodeBlock.builder()
     internal val modifiers = mutableSetOf<Modifier>()

--- a/src/main/java/io/outfoxx/typescriptpoet/ParameterSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/ParameterSpec.kt
@@ -19,7 +19,9 @@ package io.outfoxx.typescriptpoet
 import kotlin.math.min
 
 
-class ParameterSpec private constructor(builder: Builder) {
+class ParameterSpec private constructor(
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val optional = builder.optional
   val decorators = builder.decorators.toImmutableList()
@@ -81,7 +83,7 @@ class ParameterSpec private constructor(builder: Builder) {
      internal val name: String,
      internal val type: TypeName,
      val optional: Boolean = false
-  ) {
+  ) : Taggable.Builder<Builder>() {
     internal val decorators = mutableListOf<DecoratorSpec>()
     internal val modifiers = mutableListOf<Modifier>()
     internal var defaultValue: CodeBlock? = null

--- a/src/main/java/io/outfoxx/typescriptpoet/PropertySpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/PropertySpec.kt
@@ -20,8 +20,8 @@ package io.outfoxx.typescriptpoet
 /** A generated property declaration. */
 class PropertySpec
 private constructor(
-   builder: Builder
-) {
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val type = builder.type
   val javaDoc = builder.javaDoc.build()
@@ -62,10 +62,10 @@ private constructor(
   }
 
   class Builder internal constructor(
-     internal val name: String,
-     internal val type: TypeName,
-     val optional: Boolean = false
-  ) {
+    internal val name: String,
+    internal val type: TypeName,
+    val optional: Boolean = false
+  ) : Taggable.Builder<Builder>() {
     internal val javaDoc = CodeBlock.builder()
     internal val decorators = mutableListOf<DecoratorSpec>()
     internal val modifiers = mutableListOf<Modifier>()

--- a/src/main/java/io/outfoxx/typescriptpoet/Taggable.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/Taggable.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.typescriptpoet
+
+import kotlin.reflect.KClass
+
+/** A type that can be tagged with extra metadata of the user's choice. */
+abstract class Taggable(
+  /** all tags. */
+  val tags: Map<KClass<*>, Any>
+) {
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  inline fun <reified T : Any> tag(type: KClass<T>): T? = tags[type] as T?
+
+  /** Returns the tag attached with [type] as a key, or null if no tag is attached with that key. */
+  inline fun <reified T : Any> tag(type: Class<T>): T? = tag(type.kotlin)
+
+  /** The builder analogue to [Taggable] types. */
+  abstract class Builder<out B : Builder<B>> {
+
+    /** Mutable map of the current tags this builder contains. */
+    val tags: MutableMap<KClass<*>, Any> = mutableMapOf()
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    fun <T : Any> tag(type: Class<T>, tag: T?): B = tag(type.kotlin, tag)
+
+    /**
+     * Attaches [tag] to the request using [type] as a key. Tags can be read from a
+     * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+     * [type].
+     *
+     * Use this API to attach originating elements, debugging, or other application data to a spec
+     * so that you may read it in other APIs or callbacks.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Any> tag(type: KClass<T>, tag: T?): B = apply {
+      if (tag == null) {
+        this.tags.remove(type)
+      } else {
+        this.tags[type] = tag
+      }
+    } as B
+  }
+}
+
+/** Returns the tag attached with [T] as a key, or null if no tag is attached with that key. */
+inline fun <reified T : Any> Taggable.tag(): T? = tag(T::class)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> ClassSpec.Builder.tag(tag: T?): ClassSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> DecoratorSpec.Builder.tag(tag: T?): DecoratorSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> EnumSpec.Builder.tag(tag: T?): EnumSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FileSpec.Builder.tag(tag: T?): FileSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> FunctionSpec.Builder.tag(tag: T?): FunctionSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> InterfaceSpec.Builder.tag(tag: T?): InterfaceSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+
+inline fun <reified T : Any> ModuleSpec.Builder.tag(tag: T?): ModuleSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> ParameterSpec.Builder.tag(tag: T?): ParameterSpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> PropertySpec.Builder.tag(tag: T?): PropertySpec.Builder =
+  tag(T::class, tag)
+
+/**
+ * Attaches [tag] to the request using [T] as a key. Tags can be read from a
+ * request using [Taggable.tag]. Use `null` to remove any existing tag assigned for
+ * [T].
+ *
+ * Use this API to attach debugging or other application data to a spec so that you may read it in
+ * other APIs or callbacks.
+ */
+inline fun <reified T : Any> TypeAliasSpec.Builder.tag(tag: T?): TypeAliasSpec.Builder =
+  tag(T::class, tag)

--- a/src/main/java/io/outfoxx/typescriptpoet/TypeAliasSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/TypeAliasSpec.kt
@@ -20,8 +20,8 @@ package io.outfoxx.typescriptpoet
 /** A generated typealias declaration */
 class TypeAliasSpec
 private constructor(
-   builder: Builder
-) {
+  builder: Builder
+) : Taggable(builder.tags.toImmutableMap()) {
   val name = builder.name
   val type = builder.type
   val javaDoc = builder.javaDoc.build()
@@ -57,9 +57,9 @@ private constructor(
   }
 
   class Builder internal constructor(
-     internal val name: String,
-     internal val type: TypeName
-  ) {
+    internal val name: String,
+    internal val type: TypeName
+  ) : Taggable.Builder<Builder>() {
     internal val javaDoc = CodeBlock.builder()
     internal val modifiers = mutableSetOf<Modifier>()
     internal val typeVariables = mutableSetOf<TypeName.TypeVariable>()

--- a/src/test/java/io/outfoxx/typescriptpoet/test/ClassSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/ClassSpecTests.kt
@@ -23,9 +23,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("ClassSpec Tests")
 class ClassSpecTests {
+
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testClassBuilder = ClassSpec.builder("Test")
+      .tag(5)
+    val testClass = testClassBuilder.build()
+
+    assertThat(testClassBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testClass.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generates JavaDoc at before class definition")

--- a/src/test/java/io/outfoxx/typescriptpoet/test/DecoratorSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/DecoratorSpecTests.kt
@@ -20,6 +20,7 @@ import io.outfoxx.typescriptpoet.CodeBlock
 import io.outfoxx.typescriptpoet.CodeWriter
 import io.outfoxx.typescriptpoet.DecoratorSpec
 import io.outfoxx.typescriptpoet.SymbolSpec
+import io.outfoxx.typescriptpoet.tag
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
@@ -27,9 +28,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("DecoratorSpec Tests")
 class DecoratorSpecTests {
+
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testBuilder = DecoratorSpec.builder("Test")
+      .tag(5)
+    val testSpec = testBuilder.build()
+
+    assertThat(testBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testSpec.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generate inline")

--- a/src/test/java/io/outfoxx/typescriptpoet/test/EnumSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/EnumSpecTests.kt
@@ -17,8 +17,10 @@
 package io.outfoxx.typescriptpoet.test
 
 import io.outfoxx.typescriptpoet.CodeWriter
+import io.outfoxx.typescriptpoet.DecoratorSpec
 import io.outfoxx.typescriptpoet.EnumSpec
 import io.outfoxx.typescriptpoet.Modifier
+import io.outfoxx.typescriptpoet.tag
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
@@ -26,10 +28,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("EnumSpec Tests")
 class EnumSpecTests {
 
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testBuilder = EnumSpec.builder("Test")
+      .tag(5)
+    val testSpec = testBuilder.build()
+
+    assertThat(testBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testSpec.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generates JavaDoc at before class definition")

--- a/src/test/java/io/outfoxx/typescriptpoet/test/FileModuleTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/FileModuleTests.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
-
 @DisplayName("FileModule Tests")
 class FileModuleTests {
 

--- a/src/test/java/io/outfoxx/typescriptpoet/test/FunctionSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/FunctionSpecTests.kt
@@ -24,9 +24,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("FunctionSpec Tests")
 class FunctionSpecTests {
+
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testBuilder = FunctionSpec.builder("Test")
+      .tag(5)
+    val testSpec = testBuilder.build()
+
+    assertThat(testBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testSpec.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generates JavaDoc at before class definition")

--- a/src/test/java/io/outfoxx/typescriptpoet/test/InterfaceSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/InterfaceSpecTests.kt
@@ -24,9 +24,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("InterfaceSpec Tests")
 class InterfaceSpecTests {
+
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testBuilder = InterfaceSpec.builder("Test")
+      .tag(5)
+    val testSpec = testBuilder.build()
+
+    assertThat(testBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testSpec.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generates JavaDoc at before interface definition")

--- a/src/test/java/io/outfoxx/typescriptpoet/test/SymbolSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/SymbolSpecTests.kt
@@ -23,7 +23,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-
 @DisplayName("SymbolSpec Tests")
 class SymbolSpecTests {
 

--- a/src/test/java/io/outfoxx/typescriptpoet/test/TypeAliasSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/TypeAliasSpecTests.kt
@@ -20,6 +20,7 @@ import io.outfoxx.typescriptpoet.CodeWriter
 import io.outfoxx.typescriptpoet.Modifier
 import io.outfoxx.typescriptpoet.TypeAliasSpec
 import io.outfoxx.typescriptpoet.TypeName
+import io.outfoxx.typescriptpoet.tag
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
@@ -27,9 +28,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.StringWriter
 
-
 @DisplayName("TypeAliasSpec Tests")
 class TypeAliasSpecTests {
+
+  @Test
+  @DisplayName("Tags on builders can be retrieved on builders and built specs")
+  fun testTags() {
+    val testBuilder = TypeAliasSpec.builder("Test", TypeName.STRING)
+      .tag(5)
+    val testSpec = testBuilder.build()
+
+    assertThat(testBuilder.tags[Integer::class] as? Int, equalTo(5))
+    assertThat(testSpec.tag(), equalTo(5))
+  }
 
   @Test
   @DisplayName("Generates JavaDoc at before class definition")


### PR DESCRIPTION
Allows tagging specs & builders with arbitrary domain specific data.

Note that this is a near exact copy of Taggable from kotlinpoet.