### PR TITLE
Add methods for adding multiple specs at once to a FileSpecBuilder

### DIFF
--- a/src/main/java/io/outfoxx/typescriptpoet/FileModules.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/FileModules.kt
@@ -26,7 +26,7 @@ object FileModules {
       val importerPath = directory.resolve(importer).toAbsolutePath().normalize()
       val importerDir = importerPath.parent ?: importerPath
       val importPath = directory.resolve(import.drop(1)).toAbsolutePath().normalize()
-      val importedPath = importerDir.relativize(importPath).normalize().toString()
+      val importedPath = importerDir.relativize(importPath).normalize().toString().replace('\\', '/')
       if (importedPath.startsWith("."))
         importedPath
       else

--- a/src/main/java/io/outfoxx/typescriptpoet/FileSpec.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/FileSpec.kt
@@ -273,9 +273,17 @@ private constructor(
       members += moduleSpec
     }
 
+    fun addModules(moduleSpecs: Iterable<ModuleSpec>) = apply {
+      moduleSpecs.forEach { addModule(it) }
+    }
+
     fun addClass(classSpec: ClassSpec) = apply {
       checkMemberModifiers(classSpec.modifiers)
       members += classSpec
+    }
+
+    fun addClasses(classSpecs: Iterable<ClassSpec>) = apply {
+      classSpecs.forEach { addClass(it) }
     }
 
     fun addInterface(ifaceSpec: InterfaceSpec) = apply {
@@ -283,9 +291,17 @@ private constructor(
       members += ifaceSpec
     }
 
+    fun addInterfaces(ifaceSpecs: Iterable<InterfaceSpec>) = apply {
+      ifaceSpecs.forEach { addInterface(it) }
+    }
+
     fun addEnum(enumSpec: EnumSpec) = apply {
       checkMemberModifiers(enumSpec.modifiers)
       members += enumSpec
+    }
+
+    fun addEnums(enumSpecs: Iterable<EnumSpec>) = apply {
+      enumSpecs.forEach { addEnum(it) }
     }
 
     fun addType(typeSpec: AnyTypeSpec) = apply {
@@ -297,11 +313,19 @@ private constructor(
       }
     }
 
+    fun addTypes(typeSpecs: Iterable<AnyTypeSpec>) = apply {
+      typeSpecs.forEach { addType(it) }
+    }
+
     fun addFunction(functionSpec: FunctionSpec) = apply {
       require(!functionSpec.isConstructor) { "cannot add ${functionSpec.name} to file $modulePath" }
       require(functionSpec.decorators.isEmpty()) { "decorators on module functions are not allowed" }
       checkMemberModifiers(functionSpec.modifiers)
       members += functionSpec
+    }
+
+    fun addFunctions(functionSpecs: Iterable<FunctionSpec>) = apply {
+      functionSpecs.forEach { addFunction(it) }
     }
 
     fun addProperty(propertySpec: PropertySpec) = apply {
@@ -315,8 +339,16 @@ private constructor(
       members += propertySpec
     }
 
+    fun addProperties(propertySpecs: Iterable<PropertySpec>) = apply {
+      propertySpecs.forEach { addProperty(it) }
+    }
+
     fun addTypeAlias(typeAliasSpec: TypeAliasSpec) = apply {
       members += typeAliasSpec
+    }
+
+    fun addTypeAliases(typeAliasSpecs: Iterable<TypeAliasSpec>) = apply {
+      typeAliasSpecs.forEach { addTypeAlias(it) }
     }
 
     fun addCode(codeBlock: CodeBlock) = apply {

--- a/src/test/java/io/outfoxx/typescriptpoet/test/FileSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/FileSpecTests.kt
@@ -18,6 +18,7 @@ package io.outfoxx.typescriptpoet.test
 
 import io.outfoxx.typescriptpoet.ClassSpec
 import io.outfoxx.typescriptpoet.FileSpec
+import io.outfoxx.typescriptpoet.FunctionSpec
 import io.outfoxx.typescriptpoet.InterfaceSpec
 import io.outfoxx.typescriptpoet.Modifier
 import io.outfoxx.typescriptpoet.ModuleSpec
@@ -349,17 +350,15 @@ class FileSpecTests {
 
     val testFile =
       FileSpec.builder("test")
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest1", typeName1)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest2", typeName2)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("Another", typeName3)
-            .build()
+        .addTypeAliases(
+          listOf(
+            TypeAliasSpec.builder("LocalTest1", typeName1)
+              .build(),
+            TypeAliasSpec.builder("LocalTest2", typeName2)
+              .build(),
+            TypeAliasSpec.builder("Another", typeName3)
+              .build()
+          )
         )
         .build()
 
@@ -393,17 +392,15 @@ class FileSpecTests {
 
     val testFile =
       FileSpec.builder("api/client/test")
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest1", typeName1)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest2", typeName2)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("Another", typeName3)
-            .build()
+        .addTypeAliases(
+          listOf(
+            TypeAliasSpec.builder("LocalTest1", typeName1)
+              .build(),
+            TypeAliasSpec.builder("LocalTest2", typeName2)
+              .build(),
+            TypeAliasSpec.builder("Another", typeName3)
+              .build()
+          )
         )
         .build()
 
@@ -437,17 +434,15 @@ class FileSpecTests {
 
     val testFile =
       FileSpec.builder("test")
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest1", typeName1)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest2", typeName2)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("Another", typeName3)
-            .build()
+        .addTypeAliases(
+          listOf(
+            TypeAliasSpec.builder("LocalTest1", typeName1)
+              .build(),
+            TypeAliasSpec.builder("LocalTest2", typeName2)
+              .build(),
+            TypeAliasSpec.builder("Another", typeName3)
+              .build()
+          )
         )
         .build()
 
@@ -481,17 +476,15 @@ class FileSpecTests {
 
     val testFile =
       FileSpec.builder("client/api/test")
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest1", typeName1)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("LocalTest2", typeName2)
-            .build()
-        )
-        .addTypeAlias(
-          TypeAliasSpec.builder("Another", typeName3)
-            .build()
+        .addTypeAliases(
+          listOf(
+            TypeAliasSpec.builder("LocalTest1", typeName1)
+              .build(),
+            TypeAliasSpec.builder("LocalTest2", typeName2)
+              .build(),
+            TypeAliasSpec.builder("Another", typeName3)
+              .build()
+          )
         )
         .build()
 
@@ -614,6 +607,43 @@ class FileSpecTests {
           
           }
           
+        """.trimIndent()
+      )
+    )
+  }
+
+  @Test
+  fun `Simple test for outputting multiple functions`() {
+    val testFile =
+      FileSpec.builder("client/api/test")
+        .addFunctions(
+          listOf(
+            FunctionSpec.builder("logHello")
+              .addStatement("console.log('hello')")
+              .build(),
+            FunctionSpec.builder("logWorld")
+              .addStatement("console.log('world')")
+              .build(),
+          )
+        )
+        .build()
+
+    val out = StringBuilder()
+    testFile.writeTo(out)
+
+    assertThat(
+      out.toString(),
+      equalTo(
+        """
+          
+          function logHello() {
+            console.log('hello');
+          }
+  
+          function logWorld() {
+            console.log('world');
+          }
+        
         """.trimIndent()
       )
     )

--- a/src/test/java/io/outfoxx/typescriptpoet/test/FileSpecTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/FileSpecTests.kt
@@ -29,7 +29,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.nio.file.Path
+import java.nio.file.Paths
 
 @DisplayName("FileSpec Tests")
 class FileSpecTests {
@@ -57,7 +57,7 @@ class FileSpecTests {
 
     assertThat(
       buildString {
-        testFile.writeTo(this, Path.of("tester"))
+        testFile.writeTo(this, Paths.get("tester"))
       },
       equalTo(
         """
@@ -96,7 +96,7 @@ class FileSpecTests {
 
     assertThat(
       buildString {
-        testFile.writeTo(this, Path.of("tester").toAbsolutePath())
+        testFile.writeTo(this, Paths.get("tester").toAbsolutePath())
       },
       equalTo(
         """


### PR DESCRIPTION
2 commits in here

The first is to fix the unit tests which were broken for me on Windows. Import paths were emitted as `.\foo\bar\` instead of `./foo/bar` when using an exclamation mark `!` prefix 

The second adds the convenience functions discussed in #22 