### PR TITLE
Fix CodeBlock of handle CodeBlock args wrong

### DIFF
--- a/src/main/java/io/outfoxx/typescriptpoet/CodeBlock.kt
+++ b/src/main/java/io/outfoxx/typescriptpoet/CodeBlock.kt
@@ -336,7 +336,7 @@ private constructor(
     }
 
     private fun argToLiteral(o: Any?) = when (o) {
-      is CodeBlock -> o.toString()
+      is CodeBlock -> o
       else -> o.toString()
     }
 

--- a/src/test/java/io/outfoxx/typescriptpoet/test/CodeWriterTests.kt
+++ b/src/test/java/io/outfoxx/typescriptpoet/test/CodeWriterTests.kt
@@ -46,4 +46,26 @@ class CodeWriterTests {
       )
     )
   }
+
+  @Test
+  fun `test CodeBlock with import`() {
+    val testFunc = FunctionSpec.builder("test")
+      .returns(STRING)
+      .addCode(CodeBlock.of("return new %T()", TypeName.namedImport("X", "x")))
+      .build()
+
+    MatcherAssert.assertThat(
+      testFunc.toString(),
+      CoreMatchers.equalTo(
+        """
+            import { X } from 'x';
+
+            function test(): string {
+              return new X();
+            }
+
+        """.trimIndent()
+      )
+    )
+  }
 }


### PR DESCRIPTION
If CodeBlock is added to other CodeBlock via `%L` template parameter, `toString()` is used on the first CodeBlock and then added to second CodeBlock, this makes it impossible for the second code block to know the used symbols and imports required by the first CodeBlock und they are not imported in the file when rendered with FileSpec. In the CodeWriter the `%L` is handled correctly, however the CodeBlock arguments are converted to strings in CodeBlock already. 

https://github.com/outfoxx/typescriptpoet/blob/62d7d4b276b6039bd04729ddb135a9428e61b03e/src/main/java/io/outfoxx/typescriptpoet/CodeBlock.kt#L339